### PR TITLE
fix: pin transformers to v4.49.0 to resolve model loading issues

### DIFF
--- a/src/open-r1-multimodal/setup.py
+++ b/src/open-r1-multimodal/setup.py
@@ -61,7 +61,7 @@ _deps = [
     "safetensors>=0.3.3",
     "sentencepiece>=0.1.99",
     "torch>=2.5.1",
-    "transformers @ git+https://github.com/huggingface/transformers.git@main",
+    "transformers==4.49.0",
     "trl @ git+https://github.com/huggingface/trl.git@main",
     "vllm==0.6.6.post1",
     "wandb>=0.19.1",


### PR DESCRIPTION
- Fixed model loading mismatches #104  caused by recent transformers updates
- Confirmed v4.49.0 has stable support for QWenVL models
- Updated setup.py to use exact version instead of latest dev version
- Maybe is the same problem with question #92 