### PR TITLE
Update _get_per_token_logps() function for efficiency.

### DIFF
--- a/src/open-r1-multimodal/src/open_r1/trainer/grpo_trainer.py
+++ b/src/open-r1-multimodal/src/open_r1/trainer/grpo_trainer.py
@@ -481,12 +481,9 @@ class Qwen2VLGRPOTrainer(Trainer):
         logits = logits[:, :-1, :]  # (B, L-1, V), exclude the last logit: it corresponds to the next token pred
         input_ids = input_ids[:, 1:]  # (B, L-1), exclude the first input ID since we don't have logits for it
         # Compute the log probabilities for the input tokens. Use a loop to reduce memory peak.
-        per_token_logps = []
-        for logits_row, input_ids_row in zip(logits, input_ids):
-            log_probs = logits_row.log_softmax(dim=-1)
-            token_log_prob = torch.gather(log_probs, dim=1, index=input_ids_row.unsqueeze(1)).squeeze(1)
-            per_token_logps.append(token_log_prob)
-        return torch.stack(per_token_logps)
+        log_probs = logits.log_softmax(dim=-1)
+        token_log_prob = torch.gather(log_probs, dim=2, index=input_ids.unsqueeze(-1)).squeeze(-1)
+        return token_log_prob
 
 
     def _prepare_inputs(self, inputs):


### PR DESCRIPTION
change `for` loop into tensor calculation.

Original Code:
```
per_token_logps = []
for logits_row, input_ids_row in zip(logits, input_ids):
    log_probs = logits_row.log_softmax(dim=-1)
    token_log_prob = torch.gather(log_probs, dim=1, index=input_ids_row.unsqueeze(1)).squeeze(1)
    per_token_logps.append(token_log_prob)
return torch.stack(per_token_logps)
```
Original Output:

```
(Pdb) p torch.stack(per_token_logps_new)
tensor([[-2.2250e+01, -4.9062e+00, -5.4688e+00,  ..., -1.0812e+01,
         -1.0812e+01, -1.0812e+01],
        [-2.2250e+01, -4.9062e+00, -5.4688e+00,  ..., -8.5354e-05,
         -2.6226e-06, -1.2517e-05]], device='cuda:0', dtype=torch.bfloat16)
```


New Code:

```
log_probs = logits.log_softmax(dim=-1)
token_log_prob = torch.gather(log_probs, dim=2, index=input_ids.unsqueeze(-1)).squeeze(-1)
return token_log_prob
```

New Output:
```
 (Pdb) p token_log_prob
tensor([[-2.2250e+01, -4.9062e+00, -5.4688e+00,  ..., -1.0812e+01,
         -1.0812e+01, -1.0812e+01],
        [-2.2250e+01, -4.9062e+00, -5.4688e+00,  ..., -8.5354e-05,
         -2.6226e-06, -1.2517e-05]], device='cuda:0', dtype=torch.bfloat16)
```

