### PR TITLE
bug fix

### DIFF
--- a/src/open-r1-multimodal/src/open_r1/grpo_jsonl.py
+++ b/src/open-r1-multimodal/src/open_r1/grpo_jsonl.py
@@ -133,7 +133,6 @@ class GRPOScriptArguments(ScriptArguments):
 
 def extract_choice(text):
     # 1. Clean and normalize text
-    text = text.upper()  # Convert to uppercase
     text = re.sub(r'\s+', ' ', text)  # Normalize spaces
 
     # 2. Choice should not have uppercase letters before or after


### PR DESCRIPTION
When extracting options, we cannot convert each letter to uppercase because there will be an indefinite article "a" in the Answer, which could cause option "a" to be incorrectly recognized. This leads to instability in the early stages of training, and the model tends to maintain the uppercase letters of the options when answering.