### PR TITLE
Feature/v0.2.1/odLength_reward

### DIFF
--- a/src/open-r1-multimodal/src/open_r1/trainer/grpo_trainer.py
+++ b/src/open-r1-multimodal/src/open_r1/trainer/grpo_trainer.py
@@ -610,7 +610,8 @@ class VLMGRPOTrainer(Trainer):
                     ref_per_token_logps = self._get_per_token_logps(
                         model, prompt_completion_ids, attention_mask, **multimodal_inputs
                     )
-        ref_per_token_logps = ref_per_token_logps[:, prompt_length - 1:]
+        if ref_per_token_logps is not None:
+            ref_per_token_logps = ref_per_token_logps[:, prompt_length - 1:]
 
         # Decode the generated completions
         completions = self.processing_class.batch_decode(completion_ids, skip_special_tokens=True)


### PR DESCRIPTION
1. Update the grpo_jsonl.py file to add the functionality for calculating mAP rewards, supporting length penalties and the selection of different scoring types. 
2. Fix the handling logic for ref_per_token_logps in grpo_trainer.py to ensure beta=0 works for KL setting.