### PR TITLE
Fix image resize minimum-size handling

### DIFF
--- a/src/open-r1-multimodal/src/open_r1/trainer/grpo_trainer.py
+++ b/src/open-r1-multimodal/src/open_r1/trainer/grpo_trainer.py
@@ -60,7 +60,9 @@ if is_peft_available():
 if is_wandb_available():
     import wandb
 
+from open_r1.utils.image import resize_image_min_size
 from open_r1.vlm_modules.vlm_module import VLMBaseModule
+
 # What we call a reward function is a callable that takes a list of prompts and completions and returns a list of
 # rewards. When it's a string, it's a model ID, so it's loaded as a pretrained model.
 RewardFunc = Union[str, PreTrainedModel, Callable[[list, list], list[float]]]
@@ -535,21 +537,10 @@ class VLMGRPOTrainer(Trainer):
 
             for img in imgs:
                 try:
-                    # Ensure minimum dimensions of 28 pixels
-                    w, h = img.size
-                    if w < 28 or h < 28:
-                    # Calculate new dimensions maintaining aspect ratio
-                        if w < h:
-                            new_w = 28
-                            new_h = int(h * (28/w))
-                        else:
-                            new_h = 28
-                            new_w = int(w * (28/h))
-                    img = img.resize((new_w, new_h), PIL.Image.Resampling.LANCZOS)
+                    img = resize_image_min_size(img, min_size=28)
                 except:
                     pass
                 images.append(img)
-                
 
         prompt_inputs, additional_output = self.vlm_module.prepare_model_inputs(
             self.processing_class,

--- a/src/open-r1-multimodal/src/open_r1/utils/image.py
+++ b/src/open-r1-multimodal/src/open_r1/utils/image.py
@@ -1,0 +1,17 @@
+import PIL.Image
+
+
+def resize_image_min_size(image: PIL.Image.Image, min_size: int = 28) -> PIL.Image.Image:
+    """Resize an image to ensure its shortest side is at least ``min_size``."""
+    width, height = image.size
+    if width >= min_size and height >= min_size:
+        return image
+
+    if width < height:
+        new_width = min_size
+        new_height = int(height * (min_size / width))
+    else:
+        new_height = min_size
+        new_width = int(width * (min_size / height))
+
+    return image.resize((new_width, new_height), PIL.Image.Resampling.LANCZOS)

--- a/src/open-r1-multimodal/tests/test_image.py
+++ b/src/open-r1-multimodal/tests/test_image.py
@@ -1,0 +1,43 @@
+import PIL.Image
+
+from open_r1.utils.image import resize_image_min_size
+
+
+def test_resize_image_min_size_keeps_large_images():
+    image = PIL.Image.new("RGB", (224, 224))
+
+    resized = resize_image_min_size(image, min_size=28)
+
+    assert resized.size == (224, 224)
+
+
+def test_resize_image_min_size_keeps_boundary_images():
+    image = PIL.Image.new("RGB", (28, 28))
+
+    resized = resize_image_min_size(image, min_size=28)
+
+    assert resized.size == (28, 28)
+
+
+def test_resize_image_min_size_expands_small_width():
+    image = PIL.Image.new("RGB", (20, 50))
+
+    resized = resize_image_min_size(image, min_size=28)
+
+    assert resized.size == (28, 70)
+
+
+def test_resize_image_min_size_expands_small_height():
+    image = PIL.Image.new("RGB", (50, 20))
+
+    resized = resize_image_min_size(image, min_size=28)
+
+    assert resized.size == (70, 28)
+
+
+def test_resize_image_min_size_expands_equal_small_sides():
+    image = PIL.Image.new("RGB", (20, 20))
+
+    resized = resize_image_min_size(image, min_size=28)
+
+    assert resized.size == (28, 28)


### PR DESCRIPTION
## Description

Fixes the image minimum-size resize path used during GRPO generation scoring. Normal-size images are now returned unchanged, while images with either side below 28 pixels are resized once with aspect ratio preserved.

The trainer behavior for valid images is unchanged except that it no longer relies on an `UnboundLocalError`/broad exception path for normal images. A small image utility and focused tests cover the resize cases.

## Related Issue

Resolves #355.

## Motivation and Context

The previous code defined `new_w` and `new_h` only inside the small-image branch but called `img.resize((new_w, new_h), ...)` outside that branch. For normal images, this triggered exception handling as part of normal control flow. Moving the behavior into a tested helper makes the intended resize contract explicit and avoids that overhead.

## How Has This Been / Can This Be Tested?

Tested locally on Windows with Anaconda `py311` / Python 3.11.15.

```bash
D:\Dev\conda-envs\py311\python.exe -m py_compile src/open-r1-multimodal/src/open_r1/utils/image.py src/open-r1-multimodal/tests/test_image.py
$env:PYTHONPATH='src/open-r1-multimodal/src'; D:\Dev\conda-envs\py311\python.exe -m pytest src/open-r1-multimodal/tests/test_image.py
```

The focused image tests passed: `5 passed`.

## Checklist

- [x] Normal-size and boundary-size images remain unchanged.
- [x] Images below the minimum size are expanded while preserving aspect ratio.
- [x] Existing trainer fallback behavior is preserved for unexpected image errors.
- [x] Added focused tests for the resize helper.